### PR TITLE
Update hal vendor lib to 0.9.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "nocarrier/hal": "~0.9.10"
+        "nocarrier/hal": "~0.9.11"
     },
     "autoload": {
         "psr-4": {"EasyBib\\Silex\\HAL\\": "src/"}


### PR DESCRIPTION
Can call `$resource->getFirstLink('name')`, too.